### PR TITLE
hono/oauth-providers のバージョンを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@hono/node-server": "1.11.0",
-    "@hono/oauth-providers": "0.4.0",
+    "@hono/oauth-providers": "0.3.1",
     "damage-calc": "https://github.com/nnn-training/damage-calc-4006.git",
     "hono": "4.2.7",
     "iron-session": "8.0.1"


### PR DESCRIPTION
"@hono/oauth-providers": "0.4.0", だと Github でのログインが上手くできないことが分かったため、修正しました。
- https://github.com/progedu/intro-2024-edition/issues/959